### PR TITLE
Deploy Script > Update to use new Sonatype URLs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,9 +94,12 @@ publishing {
 
 nexusPublishing {
     repositories {
+        sonatype()
+    }
+    repositories {
         sonatype {
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getProperty("SONATYPE_USERNAME"))
             password.set(System.getProperty("SONATYPE_PASSWORD"))
         }


### PR DESCRIPTION
Updated Nexus Publishing per new URLs suggested [here](https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central).